### PR TITLE
Update design and add a primary mixin.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,33 +2,26 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/node:8-browsers
+      - image: 'circleci/node:10-browsers'
     steps:
       - checkout
-      - run:
-          name: Ensure package.json exists for caching
-          command: if [[ ! -f package.json ]]; then echo "{}" > package.json; fi
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}-{{ checksum "bower.json" }}
-      - run:
-          name: Install dependencies
-          command: npx origami-build-tools@^7 install
-      - save_cache:
-          key: dependency-cache-{{ checksum "package.json" }}-{{ checksum "bower.json" }}
-          paths:
-            - node_modules
-            - bower_components
-      - run:
-          name: Build accessibility testing demo
-          command: npx origami-build-tools@^7 demo --demo-filter pa11y --suppress-errors
-      - run:
-          name: Run linters
-          command: npx origami-build-tools@^7 verify
-      - run:
-          name: Run tests
-          command: npx origami-build-tools@^7 test
+      - run: npm install --only=dev
+      - run: npx origami-ci branch
+  publish_to_npm:
+    docker:
+      - image: 'circleci/node:10'
+    steps:
+      - checkout
+      - run: npm install --only=dev
+      - run: npx origami-ci release
 workflows:
   version: 2
   test:
     jobs:
       - test
+      - publish_to_npm:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,7 @@
+## Migration guide
+
+### Migrating from v1 to v2
+
+v2 updates its o-colors dependency to a new major and introduces a dependency on o-typography and o-spacing. Ensure your project dependencies does not conflict and update these components if required.
+
+v2 also updates the Sass mixin `oBigNumber` to output all o-big-number CSS. We recommend including CSS using `oBigNumber` and using default o-big-number markup. If you are unable to update your to o-big-number markup, use `oBigNumberTitle` to style the title element and continue to use `oBigNumberContent` to style the content element.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,6 @@
 
 ### Migrating from v1 to v2
 
-v2 updates its o-colors dependency to a new major and introduces a dependency on o-typography and o-spacing. Ensure your project dependencies does not conflict and update these components if required.
+v2 updates its o-colors dependency to a new major and introduces a dependency on o-typography and o-spacing. Ensure your project dependencies do not conflict and update these components if required.
 
 v2 also updates the Sass mixin `oBigNumber` to output all o-big-number CSS. We recommend including CSS using `oBigNumber` and using default o-big-number markup. If you are unable to update your to o-big-number markup, use `oBigNumberTitle` to style the title element and continue to use `oBigNumberContent` to style the content element.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # o-big-number [![Build Status](https://circleci.com/gh/Financial-Times/o-big-number.png?style=shield&circle-token=9ca314332de2a9b6a80eb8477e097d9acbc96e0b)](https://circleci.com/gh/Financial-Times/o-big-number) [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
 
-Typographical styles to highlight and describe a big number. Positioning of the big number, for example to the left in a style of a pull-quote, is left to the user. This is so o-big-number may be used in different contexts without overrides.
+Typographical styles to highlight and describe a big number. Positioning of the big number, for example to the left in a style of a pull-quote, is left to the user. This is so o-big-number may be used in different contexts without writing extra CSS to remove existing positioning.
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # o-big-number [![Build Status](https://circleci.com/gh/Financial-Times/o-big-number.png?style=shield&circle-token=9ca314332de2a9b6a80eb8477e097d9acbc96e0b)](https://circleci.com/gh/Financial-Times/o-big-number) [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
 
-Typographical styles to highlight and describe a big number. Positing of the big number, for example to the left in a style of a pull-quote, is left to the user. This is so o-big-number may be used in different contexts without overrides.
+Typographical styles to highlight and describe a big number. Positioning of the big number, for example to the left in a style of a pull-quote, is left to the user. This is so o-big-number may be used in different contexts without overrides.
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,50 @@
-# o-big-number [![Build Status](https://circleci.com/gh/Financial-Times/o-big-number.png?style=shield&circle-token=d4cdedae5153e5aa0318dcb53236ac885808a66a)](https://circleci.com/gh/Financial-Times/o-big-number)
-Big Number component [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
+# o-big-number [![Build Status](https://circleci.com/gh/Financial-Times/o-big-number.png?style=shield&circle-token=9ca314332de2a9b6a80eb8477e097d9acbc96e0b)](https://circleci.com/gh/Financial-Times/o-big-number) [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
 
-Coming soon.
+Typographical styles to highlight and describe a big number. Positing of the big number, for example to the left in a style of a pull-quote, is left to the user. This is so o-big-number may be used in different contexts without overrides.
+
+----
+
+- [Markup](#markup)
+- [Sass](#sass)
+- [Migration guide](#migration)
+- [Contact](#contact)
+- [Licence](#licence)
+
+## Markup
+
+A big number has two parts. The big number itself and copy to describe the big number.
+
+```html
+<div class="o-big-number">
+	<div class="o-big-number__title">&pound;350m</div>
+	<div class="o-big-number__content">Cost of the rights expected to increase by one-third — or about £350m a year — although some anticipate inflation of up to 70%</div>
+</div>
+```
+
+## Sass
+
+To output CSS for o-big-number make a single call to the primary mixin `oBigNumber`.
+
+```scss
+// outputs .o-big-number, o-big-number__title, etc
+@include oBigNumber();
+```
+
+We recommend you use `oBigNumber` and default `o-big-number` classes, however if you are unable to update your markup use the mixins `oBigNumberTitle` and `oBigNumberContent`:
+
+```scss
+.my-big-number-title {
+    @include oBigNumberTitle();
+}
+
+.my-big-number-content {
+    @include oBigNumberContent();
+}
+```
+
+## Migration
+
+State | Major Version | Last Minor Release | Migration guide |
+:---: | :---: | :---: | :---:
+✨ active | 2 | N/A | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+╳ deprecated | 1 | 1.1 | N/A |

--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,8 @@
     "main.scss"
   ],
   "dependencies": {
-    "o-colors": ">=2.4.4 <4"
+    "o-spacing": "^2.0.0",
+    "o-colors": "^4.10.3",
+    "o-typography": "^5.12.0"
   }
 }

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,6 +1,3 @@
-$o-big-number-is-silent: false;
 @import "../../main";
 
-body {
-	font-family: BentonSans;
-}
+@include oBigNumber();

--- a/demos/src/simple.mustache
+++ b/demos/src/simple.mustache
@@ -1,4 +1,4 @@
-<div class="o-big-number o-big-number--standard">
+<div class="o-big-number">
 	<div class="o-big-number__title">&pound;350m</div>
 	<div class="o-big-number__content">Cost of the rights expected to increase by one-third — or about £350m a year — although some anticipate inflation of up to 70%</div>
 </div>

--- a/main.scss
+++ b/main.scss
@@ -1,25 +1,21 @@
 @import "o-colors/main";
+@import "o-spacing/main";
+@import "o-typography/main";
+
 @import "src/scss/variables";
+@import "src/scss/mixins";
 
+/// Output all styles for the big number component.
 @mixin oBigNumber {
-	font-family: oFontsGetFontFamilyWithFallbacks(MetricWeb);
-	color: #000000;
-	border-left: 2px solid #000000;
-	padding-left: 10px;
-}
-
-@mixin oBigNumberTitle {
-	display: block;
-	font-size: 4em;
-	font-weight: bold;
-	line-height: 1em;
-}
-
-@if $o-big-number-is-silent == false {
-	.o-big-number {
-		@include oBigNumber;
-	}
 	.o-big-number__title {
 		@include oBigNumberTitle;
 	}
+
+	.o-big-number__content {
+		@include oBigNumberContent;
+	}
+}
+
+@if $o-big-number-is-silent == false {
+	@include oBigNumber();
 }

--- a/origami.json
+++ b/origami.json
@@ -1,5 +1,5 @@
 {
-	"description": "A pull-quote-esque component that highlights large numbers",
+	"description": "Typographical styles to highlight a big number.",
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": 1,
@@ -8,17 +8,20 @@
 		"email": "origami.support@ft.com",
 		"slack": "financialtimes/ft-origami"
 	},
-	"supportStatus": "experimental",
+	"supportStatus": "maintained",
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
-		"dependencies": "o-fonts@^1.6.3"
+		"dependencies": [
+			"o-fonts@^3.3.2",
+			"o-normalise@^1.7.4"
+		]
 	},
 	"ci": {
 		"circle": "https://circleci.com/api/v1/project/Financial-Times/o-big-number"
 	},
 	"demos": [
 		{
-			"title": "Simple",
+			"title": "Big Number",
 			"name": "simple",
 			"template": "demos/src/simple.mustache"
 		}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "name": "o-big-number",
+    "devDependencies": {
+        "origami-ci-tools": "^1.0.0"
+    }
+}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,7 +1,7 @@
 /// Styles for the big number itself.
 @mixin oBigNumberTitle {
 	@include oTypographySansBold($scale: 8);
-	margin: 0 0 oSpacingByName('s1') 0;
+	margin: 0 0 oSpacingByName('s1');
 }
 
 /// Styles for the copy under the big number.

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,0 +1,11 @@
+/// Styles for the big number itself.
+@mixin oBigNumberTitle {
+	@include oTypographySansBold($scale: 8);
+	margin: 0 0 oSpacingByName('s1') 0;
+}
+
+/// Styles for the copy under the big number.
+@mixin oBigNumberContent {
+	@include oTypographySans($scale: 1, $line-height: 22px);
+	max-width: oTypographyMaxLineWidth($scale: 1);
+}


### PR DESCRIPTION
Completes the major cascade checklist:
https://github.com/Financial-Times/o-big-number/issues/10

Updating the design of big number to meet the latest of ft.com,
so the styles may be previewed in Origami and shared.
https://github.com/Financial-Times/n-content-body/blob/master/scss/_big-number.scss#L1
https://github.com/Financial-Times/google-amp/blob/f522d994bb3c1677d8c9ccf1fa5af7c6a3b53241/scss/article.scss#L122

And removed from o-typography:
https://github.com/Financial-Times/o-typography/issues/203